### PR TITLE
fix: [PIDM-1218] change ci full name max length

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # see https://help.github.com/en/articles/about-code-owners#example-of-a-codeowners-file
 
-* @pagopa/pagopa-team-core @pagopa/pagopa-team-backoffice @alessio-cialini @svariant @gioelemella
+* @pagopa/pagopa-team-core @pagopa/pagopa-team-backoffice @svariant @gioelemella
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-print-payment-notice-service
 description: Microservice that handles services for notice print
 type: application
-version: 0.75.0
-appVersion: 0.9.10-4-PIDM-1218-fix-ci-upload-error
+version: 0.76.0
+appVersion: 0.9.10-5-PIDM-1218-fix-ci-upload-error
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-print-payment-notice-service
 description: Microservice that handles services for notice print
 type: application
-version: 0.71.0
-appVersion: 0.9.10
+version: 0.72.0
+appVersion: 0.9.10-1-PIDM-1218-fix-ci-upload-error
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-print-payment-notice-service
 description: Microservice that handles services for notice print
 type: application
-version: 0.73.0
-appVersion: 0.9.10-2-PIDM-1218-fix-ci-upload-error
+version: 0.74.0
+appVersion: 0.9.10-3-PIDM-1218-fix-ci-upload-error
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-print-payment-notice-service
 description: Microservice that handles services for notice print
 type: application
-version: 0.72.0
-appVersion: 0.9.10-1-PIDM-1218-fix-ci-upload-error
+version: 0.73.0
+appVersion: 0.9.10-2-PIDM-1218-fix-ci-upload-error
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-print-payment-notice-service
 description: Microservice that handles services for notice print
 type: application
-version: 0.74.0
-appVersion: 0.9.10-3-PIDM-1218-fix-ci-upload-error
+version: 0.75.0
+appVersion: 0.9.10-4-PIDM-1218-fix-ci-upload-error
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "print-payment-notice-service"
   image:
     repository: ghcr.io/pagopa/pagopa-print-payment-notice-service
-    tag: "0.9.10-2-PIDM-1218-fix-ci-upload-error"
+    tag: "0.9.10-3-PIDM-1218-fix-ci-upload-error"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "print-payment-notice-service"
   image:
     repository: ghcr.io/pagopa/pagopa-print-payment-notice-service
-    tag: "0.9.10"
+    tag: "0.9.10-1-PIDM-1218-fix-ci-upload-error"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "print-payment-notice-service"
   image:
     repository: ghcr.io/pagopa/pagopa-print-payment-notice-service
-    tag: "0.9.10-4-PIDM-1218-fix-ci-upload-error"
+    tag: "0.9.10-5-PIDM-1218-fix-ci-upload-error"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "print-payment-notice-service"
   image:
     repository: ghcr.io/pagopa/pagopa-print-payment-notice-service
-    tag: "0.9.10-3-PIDM-1218-fix-ci-upload-error"
+    tag: "0.9.10-4-PIDM-1218-fix-ci-upload-error"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "print-payment-notice-service"
   image:
     repository: ghcr.io/pagopa/pagopa-print-payment-notice-service
-    tag: "0.9.10-1-PIDM-1218-fix-ci-upload-error"
+    tag: "0.9.10-2-PIDM-1218-fix-ci-upload-error"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "print-payment-notice-service"
   image:
     repository: ghcr.io/pagopa/pagopa-print-payment-notice-service
-    tag: "0.9.10-2-PIDM-1218-fix-ci-upload-error"
+    tag: "0.9.10-3-PIDM-1218-fix-ci-upload-error"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "print-payment-notice-service"
   image:
     repository: ghcr.io/pagopa/pagopa-print-payment-notice-service
-    tag: "0.9.10"
+    tag: "0.9.10-1-PIDM-1218-fix-ci-upload-error"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "print-payment-notice-service"
   image:
     repository: ghcr.io/pagopa/pagopa-print-payment-notice-service
-    tag: "0.9.10-4-PIDM-1218-fix-ci-upload-error"
+    tag: "0.9.10-5-PIDM-1218-fix-ci-upload-error"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "print-payment-notice-service"
   image:
     repository: ghcr.io/pagopa/pagopa-print-payment-notice-service
-    tag: "0.9.10-3-PIDM-1218-fix-ci-upload-error"
+    tag: "0.9.10-4-PIDM-1218-fix-ci-upload-error"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "print-payment-notice-service"
   image:
     repository: ghcr.io/pagopa/pagopa-print-payment-notice-service
-    tag: "0.9.10-1-PIDM-1218-fix-ci-upload-error"
+    tag: "0.9.10-2-PIDM-1218-fix-ci-upload-error"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "print-payment-notice-service"
   image:
     repository: ghcr.io/pagopa/pagopa-print-payment-notice-service
-    tag: "0.9.10-2-PIDM-1218-fix-ci-upload-error"
+    tag: "0.9.10-3-PIDM-1218-fix-ci-upload-error"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "print-payment-notice-service"
   image:
     repository: ghcr.io/pagopa/pagopa-print-payment-notice-service
-    tag: "0.9.10"
+    tag: "0.9.10-1-PIDM-1218-fix-ci-upload-error"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "print-payment-notice-service"
   image:
     repository: ghcr.io/pagopa/pagopa-print-payment-notice-service
-    tag: "0.9.10-4-PIDM-1218-fix-ci-upload-error"
+    tag: "0.9.10-5-PIDM-1218-fix-ci-upload-error"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "print-payment-notice-service"
   image:
     repository: ghcr.io/pagopa/pagopa-print-payment-notice-service
-    tag: "0.9.10-3-PIDM-1218-fix-ci-upload-error"
+    tag: "0.9.10-4-PIDM-1218-fix-ci-upload-error"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "print-payment-notice-service"
   image:
     repository: ghcr.io/pagopa/pagopa-print-payment-notice-service
-    tag: "0.9.10-1-PIDM-1218-fix-ci-upload-error"
+    tag: "0.9.10-2-PIDM-1218-fix-ci-upload-error"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/integration-test/src/features/2_installments.feature
+++ b/integration-test/src/features/2_installments.feature
@@ -110,7 +110,7 @@ Feature: Single Generation - 2 Installments
       | Avviso.Rata2.Codice        | "347000008800999073"       |
       | Avviso.Rata2.Importo       | 140000                     |
       | Avviso.Rata2.Data          | "31/12/2025"               |
-      | Ente.CF                    | "80034390585"              |
+      | Ente.CF                    | "99999000013"              |
       | Destinatario.CF            | "FFFCST83A15L113V"         |
       | Destinatario.NomeCompleto  | "Mario Rossi"              |
       | Destinatario.Indirizzo     | "Via Nazionale"            |

--- a/integration-test/src/package.json
+++ b/integration-test/src/package.json
@@ -7,7 +7,7 @@
     "test:dev": "dotenv -e ./config/.env.dev yarn cucumber",
     "test:uat": "dotenv -e ./config/.env.uat yarn cucumber",
     "test:prod": "dotenv -e ./config/.env.prod yarn cucumber",
-    "cucumber": "npx cucumber-js --publish"
+    "cucumber": "npx cucumber-js --publish --retry 2"
   },
   "dependencies": {
     "@cucumber/cucumber": "^8.4.0",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "description": "Microservice to expose the APIs for Print Payment Notices",
     "termsOfService": "https://www.pagopa.gov.it/",
     "title": "Print Payment Notices - Service",
-    "version": "0.9.10-1-PIDM-1218-fix-ci-upload-error"
+    "version": "0.9.10-2-PIDM-1218-fix-ci-upload-error"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "description": "Microservice to expose the APIs for Print Payment Notices",
     "termsOfService": "https://www.pagopa.gov.it/",
     "title": "Print Payment Notices - Service",
-    "version": "0.9.10-4-PIDM-1218-fix-ci-upload-error"
+    "version": "0.9.10-5-PIDM-1218-fix-ci-upload-error"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "description": "Microservice to expose the APIs for Print Payment Notices",
     "termsOfService": "https://www.pagopa.gov.it/",
     "title": "Print Payment Notices - Service",
-    "version": "0.9.10"
+    "version": "0.9.10-1-PIDM-1218-fix-ci-upload-error"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "description": "Microservice to expose the APIs for Print Payment Notices",
     "termsOfService": "https://www.pagopa.gov.it/",
     "title": "Print Payment Notices - Service",
-    "version": "0.9.10-2-PIDM-1218-fix-ci-upload-error"
+    "version": "0.9.10-3-PIDM-1218-fix-ci-upload-error"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "description": "Microservice to expose the APIs for Print Payment Notices",
     "termsOfService": "https://www.pagopa.gov.it/",
     "title": "Print Payment Notices - Service",
-    "version": "0.9.10-3-PIDM-1218-fix-ci-upload-error"
+    "version": "0.9.10-4-PIDM-1218-fix-ci-upload-error"
   },
   "servers": [
     {

--- a/openapi/openapi_external.json
+++ b/openapi/openapi_external.json
@@ -4,7 +4,7 @@
     "description": "Microservice to expose the APIs for Print Payment Notices",
     "termsOfService": "https://www.pagopa.gov.it/",
     "title": "Print Payment Notices - Service - Payment Notice Service (External)",
-    "version": "0.9.10-2-PIDM-1218-fix-ci-upload-error"
+    "version": "0.9.10-3-PIDM-1218-fix-ci-upload-error"
   },
   "servers": [
     {

--- a/openapi/openapi_external.json
+++ b/openapi/openapi_external.json
@@ -4,7 +4,7 @@
     "description": "Microservice to expose the APIs for Print Payment Notices",
     "termsOfService": "https://www.pagopa.gov.it/",
     "title": "Print Payment Notices - Service - Payment Notice Service (External)",
-    "version": "0.9.10-3-PIDM-1218-fix-ci-upload-error"
+    "version": "0.9.10-4-PIDM-1218-fix-ci-upload-error"
   },
   "servers": [
     {

--- a/openapi/openapi_external.json
+++ b/openapi/openapi_external.json
@@ -4,7 +4,7 @@
     "description": "Microservice to expose the APIs for Print Payment Notices",
     "termsOfService": "https://www.pagopa.gov.it/",
     "title": "Print Payment Notices - Service - Payment Notice Service (External)",
-    "version": "0.9.10"
+    "version": "0.9.10-1-PIDM-1218-fix-ci-upload-error"
   },
   "servers": [
     {

--- a/openapi/openapi_external.json
+++ b/openapi/openapi_external.json
@@ -4,7 +4,7 @@
     "description": "Microservice to expose the APIs for Print Payment Notices",
     "termsOfService": "https://www.pagopa.gov.it/",
     "title": "Print Payment Notices - Service - Payment Notice Service (External)",
-    "version": "0.9.10-4-PIDM-1218-fix-ci-upload-error"
+    "version": "0.9.10-5-PIDM-1218-fix-ci-upload-error"
   },
   "servers": [
     {

--- a/openapi/openapi_external.json
+++ b/openapi/openapi_external.json
@@ -4,7 +4,7 @@
     "description": "Microservice to expose the APIs for Print Payment Notices",
     "termsOfService": "https://www.pagopa.gov.it/",
     "title": "Print Payment Notices - Service - Payment Notice Service (External)",
-    "version": "0.9.10-1-PIDM-1218-fix-ci-upload-error"
+    "version": "0.9.10-2-PIDM-1218-fix-ci-upload-error"
   },
   "servers": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>print-payment-notices-service</artifactId>
-    <version>0.9.10-4-PIDM-1218-fix-ci-upload-error</version>
+    <version>0.9.10-5-PIDM-1218-fix-ci-upload-error</version>
     <name>Print Payment Notices - Service</name>
     <description>Microservice to expose the APIs for Print Payment Notices</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>print-payment-notices-service</artifactId>
-    <version>0.9.10-2-PIDM-1218-fix-ci-upload-error</version>
+    <version>0.9.10-3-PIDM-1218-fix-ci-upload-error</version>
     <name>Print Payment Notices - Service</name>
     <description>Microservice to expose the APIs for Print Payment Notices</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>print-payment-notices-service</artifactId>
-    <version>0.9.10-1-PIDM-1218-fix-ci-upload-error</version>
+    <version>0.9.10-2-PIDM-1218-fix-ci-upload-error</version>
     <name>Print Payment Notices - Service</name>
     <description>Microservice to expose the APIs for Print Payment Notices</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>print-payment-notices-service</artifactId>
-    <version>0.9.10-3-PIDM-1218-fix-ci-upload-error</version>
+    <version>0.9.10-4-PIDM-1218-fix-ci-upload-error</version>
     <name>Print Payment Notices - Service</name>
     <description>Microservice to expose the APIs for Print Payment Notices</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>print-payment-notices-service</artifactId>
-    <version>0.9.10</version>
+    <version>0.9.10-1-PIDM-1218-fix-ci-upload-error</version>
     <name>Print Payment Notices - Service</name>
     <description>Microservice to expose the APIs for Print Payment Notices</description>
 

--- a/src/main/java/it/gov/pagopa/payment/notices/service/model/institutions/UploadData.java
+++ b/src/main/java/it/gov/pagopa/payment/notices/service/model/institutions/UploadData.java
@@ -24,7 +24,7 @@ public class UploadData {
     @Schema(description = "CI full name", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull
     @NotEmpty
-    @Size(max = 50)
+    @Size(max = 100)
     private String fullName;
 
     @Schema(description = "CI organization unit managing the payment")

--- a/src/main/java/it/gov/pagopa/payment/notices/service/model/institutions/UploadData.java
+++ b/src/main/java/it/gov/pagopa/payment/notices/service/model/institutions/UploadData.java
@@ -24,7 +24,7 @@ public class UploadData {
     @Schema(description = "CI full name", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull
     @NotEmpty
-    @Size(max = 100)
+    @Size(max = 80)
     private String fullName;
 
     @Schema(description = "CI organization unit managing the payment")

--- a/src/main/java/it/gov/pagopa/payment/notices/service/model/institutions/UploadData.java
+++ b/src/main/java/it/gov/pagopa/payment/notices/service/model/institutions/UploadData.java
@@ -24,7 +24,7 @@ public class UploadData {
     @Schema(description = "CI full name", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull
     @NotEmpty
-    @Size(max = 80)
+    @Size(max = 100)
     private String fullName;
 
     @Schema(description = "CI organization unit managing the payment")

--- a/src/test/java/it/gov/pagopa/payment/notices/service/controller/InstitutionsControllerTest.java
+++ b/src/test/java/it/gov/pagopa/payment/notices/service/controller/InstitutionsControllerTest.java
@@ -164,4 +164,54 @@ class InstitutionsControllerTest {
         verify(institutionsService).getInstitutionData(any());
     }
 
+    @Test
+    void updateInstitutionsShouldReturnOkWithFullNameAt100Chars() throws Exception {
+        String fullName100Chars = "A".repeat(100);
+        UploadData uploadData =
+                UploadData.builder()
+                        .cbill("cbill")
+                        .info("info")
+                        .webChannel(true)
+                        .appChannel(false)
+                        .taxCode("123132")
+                        .posteAccountNumber("1313")
+                        .fullName(fullName100Chars)
+                        .organization("test")
+                        .physicalChannel("1212")
+                        .build();
+        String url = "/institutions/data";
+        mvc.perform(multipart(url)
+                        .file("file", "".getBytes())
+                        .part(new MockPart("institutions-data",
+                                objectMapper.writeValueAsString(uploadData).getBytes()))
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(status().isOk());
+        verify(institutionsService).uploadInstitutionsData(any(), any());
+    }
+
+    @Test
+    void updateInstitutionsShouldReturnBadRequestWithFullNameOver100Chars() throws Exception {
+        String fullName101Chars = "A".repeat(101);
+        UploadData uploadData =
+                UploadData.builder()
+                        .cbill("cbill")
+                        .info("info")
+                        .webChannel(true)
+                        .appChannel(false)
+                        .taxCode("123132")
+                        .posteAccountNumber("1313")
+                        .fullName(fullName101Chars)
+                        .organization("test")
+                        .physicalChannel("1212")
+                        .build();
+        String url = "/institutions/data";
+        mvc.perform(multipart(url)
+                        .file("file", "".getBytes())
+                        .part(new MockPart("institutions-data",
+                                objectMapper.writeValueAsString(uploadData).getBytes()))
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(status().isBadRequest());
+        verify(institutionsService, never()).uploadInstitutionsData(any(), any());
+    }
+
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- ✅ changed CI fullName max length from 50 to 100
- ✅ update P&D template https://github.com/pagopa/pagopa-template-notice-pdf/pull/13
- 🚧 `TODO` run template action
- 🚧 `TODO` update docs https://docs.pagopa.it/avviso-pagamento/allegato-2/specifiche-tecniche/informazioni-sullente-creditore#dimensioni-1

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change is required to avoid `"An error occurred while adding/editing notice ci data"` generic error when trying to save the payment-notices form from selfcare service

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- frontend deployed locally against dev environment, changed the name field to be editable and tested both cases, before and after the fix (name <= and > 100 chars, see screenshots)

Note: integration test failure on 1 scenario is out of scope since it was already existent in past code reviews, e.g. https://github.com/pagopa/pagopa-print-payment-notice-service/actions/runs/19861001194/job/56910806729

#### Screenshots (if appropriate):

Before the fix:

1. form saved with a name field of exactly 50 characters -> OK<br>
<img width="1164" height="607" alt="image" src="https://github.com/user-attachments/assets/5d226d80-b280-495e-8a36-aa11391589cd" /> <br>

2. form saved with a name field of exactly 51 characters -> ERROR<br>
<img width="1484" height="1129" alt="image" src="https://github.com/user-attachments/assets/aa38cde8-1f3d-47b7-bfc9-a630510c5afa" /><br>

#### After the fix (max length 100 char):

1. form saved with a name field of exactly 80 characters -> OK
<img width="2419" height="1118" alt="image" src="https://github.com/user-attachments/assets/74a40d77-ae67-43b1-8564-01c799c36c66" />
<br>

2. form saved with a name field of exactly 101 characters -> ERROR
<img width="2464" height="1182" alt="image" src="https://github.com/user-attachments/assets/fd66fcbd-34fe-4b4d-9d4b-b3f3cec2433d" />

<br><br>

3. Example test notice generated using a CI name of 80 chars: <br>
[80RealCharsNotice.pdf](https://github.com/user-attachments/files/24610490/80RealCharsNotice.pdf) <br>

4. Example test notice generated using a CI name of 100 chars: <br>
[100RealCharsNotice.pdf](https://github.com/user-attachments/files/24611329/100RealCharsNotice.pdf)


#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
